### PR TITLE
Initialize pendingState from hash state

### DIFF
--- a/src/backbone.hashmodels.js
+++ b/src/backbone.hashmodels.js
@@ -393,12 +393,16 @@ Backbone.HashModels = (function(Backbone, _, $){
             }
 
             // If you load the page with a initial hash string, sync the
-            // model object to with the hash state
+            // model object with the hash state
             if (state[modelId]) {
                 if (model.setState) {
                     model.setState(state[modelId]);
                 } else {
                     model.set(state[modelId]);
+                }
+                if (!options.updateOnChange) {
+                    pendingState[modelId] = state[modelId];
+                    pendingStateString = encodeStateObject(pendingState);
                 }
             }
 


### PR DESCRIPTION
In manual update mode, pendingState contains all model state. When the page is loaded with a URL hash, pendingState wasn't being initialized so trying to "save state" immediately wouldn't get the state that came from the hash.
