### PR TITLE
Fix update method to not apply undefined pendingState

### DIFF
--- a/src/backbone.hashmodels.js
+++ b/src/backbone.hashmodels.js
@@ -213,7 +213,7 @@ Backbone.HashModels = (function(Backbone, _, $){
     var initialModelStates = {};
     var state = {};
     var stateString = '';
-    var pendingState = {};
+    var pendingState;
     var pendingStateString = '';
 
     var validdateEncodedCompressesStateString = function (s) {
@@ -276,6 +276,7 @@ Backbone.HashModels = (function(Backbone, _, $){
                 updateHash(stateString);
                 HashModels.trigger('change', stateString);
             } else {
+                pendingState = pendingState || {};
                 pendingState[modelId] = newValues;
                 pendingStateString = encodeStateObject(pendingState);
             }
@@ -339,7 +340,7 @@ Backbone.HashModels = (function(Backbone, _, $){
             initialModelStates = {};
             state = {};
             stateString = '';
-            pendingState = {};
+            pendingState = undefined;
             pendingStateString = '';
 
             updateHash = options.hashUpdateCallback || defaultHashUpdateFunction;
@@ -408,8 +409,10 @@ Backbone.HashModels = (function(Backbone, _, $){
         },
 
         update: function() {
-            state = _.extend({}, pendingState);
-            stateString = pendingStateString;
+            if (pendingState !== undefined) {
+                state = _.extend(state, pendingState);
+                stateString = encodeStateObject(state);
+            }
             updateHash(stateString);
             HashModels.trigger('change', stateString);
         },


### PR DESCRIPTION
Previous to this commit calling update immediatly after loading
the page with an intial hash would cause the initial state to be
overwritten by the empty pending state. I fixed this by leaving
pending state undefined and only applying it when calling update
only if there has been a change.

Alternative solution to #2
