### PR TITLE
Expose public method for manual hash change

### DIFF
--- a/src/backbone.hashmodels.js
+++ b/src/backbone.hashmodels.js
@@ -413,6 +413,10 @@ Backbone.HashModels = (function(Backbone, _, $){
                 state = _.extend(state, pendingState);
                 stateString = encodeStateObject(state);
             }
+            this.triggerStateChange(stateString);
+        },
+
+        triggerStateChange: function(stateString) {
             updateHash(stateString);
             HashModels.trigger('change', stateString);
         },


### PR DESCRIPTION
A project which uses this library has a need to use the same encoded
string generated for the hash, but as a source that is triggered by a UI
event.  I want to expose a method on the hashModel object to allow
manual changes to be initiated.