### PR TITLE
Add option to force model update.

### DIFF
--- a/src/backbone.hashmodels.js
+++ b/src/backbone.hashmodels.js
@@ -418,7 +418,7 @@ Backbone.HashModels = (function(Backbone, _, $){
 
         triggerStateChange: function(stateString) {
             updateHash(stateString);
-            HashModels.trigger('change', stateString);
+            handleHashChanged(stateString);
         },
 
         decodeStateObject: decodeStateObject,

--- a/src/backbone.hashmodels.js
+++ b/src/backbone.hashmodels.js
@@ -287,10 +287,10 @@ Backbone.HashModels = (function(Backbone, _, $){
         }
     };
 
-    var handleHashChanged = function (hash) {
+    var handleHashChanged = function (hash, force) {
         var newState = {};
         var newStateString = '';
-        if (hash === stateString) {
+        if (hash === stateString && !force) {
             return;
         }
         if (hash) {
@@ -413,12 +413,13 @@ Backbone.HashModels = (function(Backbone, _, $){
                 state = _.extend(state, pendingState);
                 stateString = encodeStateObject(state);
             }
-            this.triggerStateChange(stateString);
+            updateHash(stateString);
+            HashModels.trigger('change', stateString);
         },
 
-        triggerStateChange: function(stateString) {
+        triggerStateChange: function(stateString, force) {
             updateHash(stateString);
-            handleHashChanged(stateString);
+            handleHashChanged(stateString, force);
         },
 
         decodeStateObject: decodeStateObject,


### PR DESCRIPTION
- Force handleHashChanged to update the model state
  even if the state has not changed.
- This is useful for when the state becomes stale,
  and you want to force a change event to fire.
